### PR TITLE
add dependency to magento configurable to fix extension attribute cla…

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Grin_Module" setup_version="1.1.0" />
+    <module name="Grin_Module" setup_version="1.1.0" >
+        <sequence>
+            <module name="Magento_ConfigurableProduct"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
This is to fix error:
Uncaught Error: Call to undefined method Magento\ConfigurableProduct\Api\Data\OptionExtension::setAttributeData() in .../vendor/grin/module/Plugin/AttributeData.php:60

Cause:
In some deployment scenarios the configurable product extension attributes may be generated first and never regenerated after grin works with them.

Fix:
Use sequence dependencies where applicable. Add a dependency to Magento_ConfigurableProduct.