### PR TITLE
Update SalesRuleValidator and ValidateByToken for Coupon Code Validation

### DIFF
--- a/Model/SalesRuleValidator.php
+++ b/Model/SalesRuleValidator.php
@@ -40,7 +40,7 @@ class SalesRuleValidator
     {
         $code = $rule->getPrimaryCoupon()->getCode();
 
-        if (!is_null($code) && $rule->getData('is_grin_only') && in_array($code, $couponCode)) {
+        if ($code !== null && $rule->getData('is_grin_only') && in_array($code, $couponCode)) {
             return $this->request->getHeader(self::TOKEN_HEADER) === $this->systemConfig->getSalesRuleToken();
         }
 

--- a/Model/SalesRuleValidator.php
+++ b/Model/SalesRuleValidator.php
@@ -32,13 +32,15 @@ class SalesRuleValidator
     }
 
     /**
-     * @param Rule $rule
-     * @param string $couponCode
+     * @param  Rule  $rule
+     * @param  array $couponCode
      * @return bool
      */
-    public function isValid(Rule $rule, string $couponCode): bool
+    public function isValid(Rule $rule, array $couponCode): bool
     {
-        if ($rule->getData('is_grin_only') && ($rule->getPrimaryCoupon()->getCode() === $couponCode)) {
+        $code = $rule->getPrimaryCoupon()->getCode();
+
+        if (!is_null($code) && $rule->getData('is_grin_only') && in_array($code, $couponCode)) {
             return $this->request->getHeader(self::TOKEN_HEADER) === $this->systemConfig->getSalesRuleToken();
         }
 

--- a/Plugin/Magento/SalesRule/Model/RulesApplier/ValidateByToken.php
+++ b/Plugin/Magento/SalesRule/Model/RulesApplier/ValidateByToken.php
@@ -41,7 +41,7 @@ class ValidateByToken
         $couponCode
     ): array {
         foreach ($rules as $rule) {
-            if (!$this->salesRuleValidator->isValid($rule, (string) $couponCode)) {
+            if (!$this->salesRuleValidator->isValid($rule, $couponCode)) {
                 return $proceed($item, [], $skipValidation, $couponCode);
             }
         }


### PR DESCRIPTION
- Changed the parameter type of `SalesRuleValidator::isValid` method from `string` to `array` to handle multiple coupon codes.
- Modified the `SalesRuleValidator::isValid` method to validate against an array of coupon codes using `in_array`.
- Updated `ValidateByToken` plugin to pass the coupon code as an array instead of casting it to a string.

These changes enhance the validation process by allowing multiple coupon codes to be checked, ensuring greater flexibility and accuracy.