### PR TITLE
Add sample data installation and unit test configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,23 @@
 
 Influencer marketing for ecommerce. For more information go to https://grin.co/
 
+## Table of Contents
 
-Install
--
+- [Install](#install)
+- [Update](#update)
+- [Some notes](#some-notes)
+- [Q&A](#qa)
+- [Local Development](#local-development)
+  - [Prerequisites](#prerequisites)
+  - [Port Configuration](#port-configuration)
+  - [Getting Required Credentials](#getting-required-credentials)
+  - [Setup Steps](#setup-steps)
+  - [Development Workflow](#development-workflow)
+  - [Troubleshooting](#troubleshooting)
+  - [Running Unit Tests](#running-unit-tests)
+- [Credits](#credits)
+
+## Install
 
 1. composer config repositories.grin vcs https://github.com/grininc/grin-magento-module
 2. composer require grin/module
@@ -13,8 +27,7 @@ Install
 5. bin/magento setup:static-content:deploy
 6. bin/magento cache:flush
 
-Update
--
+## Update
 
 1. composer update grin/module
 2. bin/magento setup:upgrade
@@ -22,16 +35,14 @@ Update
 4. bin/magento setup:static-content:deploy
 5. bin/magento cache:flush
 
-Some notes
--
+## Some notes
 
 - Grin uses composer to provide their extension to the end customer.
 - The extension follows semver principles.
 - Once the new implementation of Grin_Affiliate is ready to be installed and tested it will get version 2.0.x.
 - If an end-user has the previous version of the extension installed via https://docs.magento.com/user-guide/v2.3/system/web-setup-wizard.html or manually in app/code, the extension must be removed before new installation.
 
-Q&A
--
+## Q&A
 
 1. Issue: I updated the extension, but it seems like the old version is installed despite the fact that in the compose.lock file I see the updated version of the extension.
 
@@ -56,16 +67,59 @@ Possible solution: in this case, according to Magento documentation, you need to
 ...
 ```
 
-Local Development
--
+## Local Development
 
 This module uses Docker for local development. Follow these steps to set up your development environment:
 
 ### Prerequisites
 
-1. Docker and Docker Compose installed on your machine
-2. Magento Marketplace credentials
-3. GitHub Personal Access Token
+- Docker
+- Docker Compose
+- PHP 8.1 or higher
+- Composer
+
+### Installation
+
+1. Clone the repository
+2. Install dependencies:
+   ```bash
+   composer install
+   ```
+3. Copy the environment file:
+   ```bash
+   cp .env.example .env
+   ```
+4. Start the Docker containers:
+   ```bash
+   docker-compose up -d
+   ```
+5. Install the module:
+   ```bash
+   ./scripts/install-module.sh
+   ```
+
+### Installing Sample Data
+
+To populate your Magento store with sample products, categories, and other content, you can use the provided script:
+
+```bash
+./scripts/install-sample-data.sh
+```
+
+This script will:
+1. Set Magento to developer mode
+2. Install the sample data
+3. Run setup upgrade
+4. Clean and flush the cache
+
+After running this script, you'll have:
+- Sample products to test with
+- Categories
+- Customer accounts
+- Sales rules (including coupon codes)
+- And more
+
+This makes it easier to test functionality like coupon codes and other features that require store content.
 
 ### Port Configuration
 
@@ -135,6 +189,19 @@ These ports are automatically configured during setup to avoid conflicts with ot
   - Username: `admin`
   - Password: `admin123`
 
+#### After Code Changes
+
+When you modify plugin code or other PHP files:
+1. Clear the Magento cache:
+   ```bash
+   cd .docker-magento
+   bin/clinotty bin/magento cache:clean
+   bin/clinotty bin/magento cache:flush
+   ```
+2. Refresh your browser page
+
+> **Note**: In developer mode, you don't need to run `setup:di:compile` after every change. However, if you're in production mode, you would need to run it.
+
 ### Troubleshooting
 
 If you encounter any issues:
@@ -159,6 +226,24 @@ If you encounter any issues:
    bin/clinotty tail -f var/log/system.log
    ```
 
-### Credits
+### Running Unit Tests
 
-This local development setup is based on [markshust/docker-magento](https://github.com/markshust/docker-magento). 
+To run unit tests for this module, use the provided script:
+
+```bash
+./scripts/run-tests.sh
+```
+
+- This will run all tests in the `Test` directory.
+
+To run a specific test file, provide the relative path from the module root:
+
+```bash
+./scripts/run-tests.sh Test/Unit/Plugin/Magento/SalesRule/Model/RulesApplier/ValidateByTokenTest.php
+```
+
+The script will automatically execute the tests inside the Docker container using the correct environment.
+
+## Credits
+
+This local development setup is based on [markshust/docker-magento](https://github.com/markshust/docker-magento).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
+         colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="/var/www/html/dev/tests/unit/framework/bootstrap.php">
+    <testsuites>
+        <testsuite name="Grin Module Test Suite">
+            <directory suffix="Test.php">./Test/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./Test/Unit</directory>
+            <exclude>
+                <directory>./Test/Api</directory>
+                <directory>./.docker-magento</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="app_etc" value=".docker-magento/app/etc"/>
+        <env name="TESTS_MAGENTO_INSTALLATION" value=".docker-magento"/>
+        <env name="TESTS_CLEANUP" value="enabled"/>
+    </php>
+</phpunit> 

--- a/scripts/install-sample-data.sh
+++ b/scripts/install-sample-data.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Change to the Magento root directory
+cd .docker-magento
+
+echo "Setting developer mode..."
+bin/magento deploy:mode:set developer
+
+echo "Installing sample data..."
+bin/magento sampledata:deploy
+
+echo "Running setup upgrade..."
+bin/magento setup:upgrade
+
+echo "Cleaning cache..."
+bin/magento cache:clean
+
+echo "Flushing cache..."
+bin/magento cache:flush
+
+echo "Sample data installation completed!" 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get the root directory (parent of scripts directory)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Change to .docker-magento directory
+cd "$ROOT_DIR/.docker-magento"
+
+if [ -z "$1" ]; then
+    # No parameter: run all tests in the Test directory
+    echo "Listing all tests:"
+    ./bin/clinotty vendor/bin/phpunit --configuration /var/www/html/app/code/Grin/Module/phpunit.xml --list-tests "/var/www/html/app/code/Grin/Module/Test"
+    echo -e "\nRunning tests:"
+    ./bin/clinotty vendor/bin/phpunit --configuration /var/www/html/app/code/Grin/Module/phpunit.xml "/var/www/html/app/code/Grin/Module/Test"
+else
+    # Parameter provided: run the specific test file
+    echo "Listing tests in file:"
+    ./bin/clinotty vendor/bin/phpunit --configuration /var/www/html/app/code/Grin/Module/phpunit.xml --list-tests "/var/www/html/app/code/Grin/Module/$1"
+    echo -e "\nRunning tests:"
+    ./bin/clinotty vendor/bin/phpunit --configuration /var/www/html/app/code/Grin/Module/phpunit.xml "/var/www/html/app/code/Grin/Module/$1"
+fi 


### PR DESCRIPTION
# Description
## Changes
- Added `phpunit.xml` configuration file for unit tests
- Created `scripts/install-sample-data.sh` script to install Magento sample data
- Created `scripts/run-tests.sh` script to run unit tests
- Updated README.md with:
  - Table of contents
  - Sample data installation instructions
  - Unit test running instructions
  - Improved local development documentation
  - Cache clearing instructions after code changes

## Why
These changes improve the development experience by:
1. Making it easier to test functionality with sample data
2. Providing a standardized way to run unit tests
3. Improving documentation for local development
4. Adding proper PHPUnit configuration for testing

## Notes
The sample data installation will help developers test features like coupon codes and other functionality that requires store content.


<img width="1618" alt="Screenshot 2025-05-30 at 2 34 33 PM" src="https://github.com/user-attachments/assets/ef8854d1-0fd0-463e-8bac-911f590cad58" />

<img width="1234" alt="Screenshot 2025-05-30 at 3 01 17 PM" src="https://github.com/user-attachments/assets/de164338-c7a1-4363-a3fb-311250ab00da" />
