### PR TITLE
Use webhook instances URL path instead of Platform instances

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -18,7 +18,7 @@
                 <active>1</active>
             </scripts>
             <webhook>
-                <url>https://app.grin.co/ecommerce/magento/webhook</url>
+                <url>https://webhooks.grin.co/ecommerce/magento/webhook</url>
             </webhook>
         </grin_integration>
     </default>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the webhook URL for Grin integration in the configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->